### PR TITLE
Add logo script to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -139,6 +139,13 @@
   <div id="root"><!--app-html--></div>
   <!--app-head-->
   <script type="module" src="/src/entry-client.tsx"></script>
+  <script type="text/javascript"> //<![CDATA[
+    var tlJsHost = ((window.location.protocol == "https:") ? "https://secure.trust-provider.com/" : "http://www.trustlogo.com/");
+    document.write(unescape("%3Cscript src='" + tlJsHost + "trustlogo/javascript/trustlogo.js' type='text/javascript'%3E%3C/script%3E"));
+  //]]></script>
+  <script language="JavaScript" type="text/javascript">
+    TrustLogo("https://www.positivessl.com/images/seals/positivessl_trust_seal_md_167x42.png", "POSDV", "none");
+  </script>
 </body>
 
 </html>


### PR DESCRIPTION
Add the provided script code before the `</body>` tag in `index.html`.

* Add the script to load the TrustLogo JavaScript file.
* Add the script to display the PositiveSSL trust seal.
